### PR TITLE
docs: use shared attributes

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,3 +1,6 @@
+:branch: current
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 ifdef::env-github[]
 NOTE: For the best reading experience,
 please view this documentation at https://www.elastic.co/guide/en/apm/agent/js-base[elastic.co]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -7,10 +7,10 @@ The Elastic APM Frontend JavaScript agent sends performance metrics and errors t
 The agent is only one of multiple components you need to get started with APM.
 Please also have a look at the documentation for
 
- * https://www.elastic.co/guide/en/apm/server/current/index.html[APM Server]
+ * {apm-server-ref}[APM Server]
  ** APM JavaScript agent is compatible with APM Server v6.2+.
- ** For APM Server 6.2, Please https://www.elastic.co/guide/en/apm/server/6.2/frontend.html[enable frontend support in the configuration].
- * https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html[Elasticsearch]
+ ** For APM Server 6.2, Please {apm-server-ref-62}/frontend.html[enable frontend support in the configuration].
+ * {ref}[Elasticsearch]
 
 
 [[getting-started]]


### PR DESCRIPTION
Use the shared attributes provided
by elastic/docs for linking to other
product docs, forums, etc.

Requires https://github.com/elastic/docs/pull/370