### PR TITLE
Docs: version cross document links in 1.x

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,5 @@
 :branch: current
+:server-branch: 6.4
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,5 +1,5 @@
-:branch: current
-:server-branch: 6.4
+:branch: 6.4
+:server-branch: {branch}
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -7,9 +7,9 @@ The Elastic APM RUM JavaScript agent sends performance metrics and errors to the
 The agent is only one of multiple components you need to get started with APM.
 Please also have a look at the documentation for
 
- * {apm-server-ref}[APM Server]
+ * {apm-server-ref-v}[APM Server]
  ** APM JavaScript agent is compatible with APM Server v6.4+.
- ** {apm-server-ref}/rum.html[enable frontend endpoints in the apm-server configuration].
+ ** {apm-server-ref-v}/rum.html[enable frontend endpoints in the apm-server configuration].
  * {ref}[Elasticsearch]
 
 

--- a/docs/sourcemap.asciidoc
+++ b/docs/sourcemap.asciidoc
@@ -6,7 +6,7 @@ However, debugging minified files is inherently difficult. To resolve this issue
 you can generate source maps for your bundles and upload them to the APM server.
 
 Here is an example to generate source maps with webpack and configure the JavaScript agent accordingly.
-For a detailed description of APM Server source map endpoint see {apm-server-ref}/sourcemaps.html[our documentation].
+For a detailed description of APM Server source map endpoint see {apm-server-ref-v}/sourcemaps.html[our documentation].
 
 First you need to configure webpack to generate source map and provide the service version to your app:
 
@@ -123,7 +123,7 @@ curl http://localhost:8200/v1/rum/sourcemaps -X POST \
 [[secret-token]]
 === Using a secret token
 
-You can {apm-server-ref}/securing-apm-server.html#secret-token[configure a secret token on APM Server] to restrict uploading sourcemaps.
+You can {apm-server-ref-v}/securing-apm-server.html#secret-token[configure a secret token on APM Server] to restrict uploading sourcemaps.
 
 Here's how to add the secret token to a curl command:
 


### PR DESCRIPTION
Versions 1.x docs links to Elastic stack v6.4 per https://github.com/elastic/apm/issues/19