### PR TITLE
chore: add script to create & upload release assets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5146,6 +5146,27 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "gh-release-assets": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/gh-release-assets/-/gh-release-assets-1.1.2.tgz",
+      "integrity": "sha1-771OrzKUoZhWNr/2s7lkXY/9lFc=",
+      "dev": true,
+      "requires": {
+        "async": "^0.9.0",
+        "mime": "^1.3.4",
+        "progress-stream": "^2.0.0",
+        "request": "^2.85.0",
+        "util-extend": "^1.0.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        }
+      }
+    },
     "git-raw-commits": {
       "version": "1.3.6",
       "resolved": "http://registry.npmjs.org/git-raw-commits/-/git-raw-commits-1.3.6.tgz",
@@ -8078,6 +8099,16 @@
       "integrity": "sha512-/OLz5F9beZUWwSHZDreXgap1XShX6W+DCHQCqwCF7uZ88s6uTlD2cR3JBE77SegCmNtb1Idst+NfmwcdU6KVhw==",
       "dev": true
     },
+    "progress-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-2.0.0.tgz",
+      "integrity": "sha1-+sY6Cz0R3qy7CWmrzJOyFLzhntU=",
+      "dev": true,
+      "requires": {
+        "speedometer": "~1.0.0",
+        "through2": "~2.0.3"
+      }
+    },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -9696,6 +9727,12 @@
       "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
       "dev": true
     },
+    "speedometer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
+      "integrity": "sha1-zWccsGdSwivKM3Di8zREC+T8YuI=",
+      "dev": true
+    },
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -10898,6 +10935,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "util-extend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
       "dev": true
     },
     "utils-merge": {

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "url": "https://github.com/elastic/apm-agent-js-base.git"
   },
   "scripts": {
-    "prepare-patch": "sh ./node_modules/elastic-apm-js-core/dev-utils/prepare-release patch && npm run build && npm run push-release",
-    "prepare-minor": "sh ./node_modules/elastic-apm-js-core/dev-utils/prepare-release minor && npm run build && npm run push-release",
-    "prepare-major": "sh ./node_modules/elastic-apm-js-core/dev-utils/prepare-release major && npm run build && npm run push-release",
-    "push-release": "git push origin master --follow-tags && npm publish",
+    "prepare-patch": "sh ./node_modules/elastic-apm-js-core/dev-utils/prepare-release patch && npm run build && npm run release",
+    "prepare-minor": "sh ./node_modules/elastic-apm-js-core/dev-utils/prepare-release minor && npm run build && npm run release",
+    "prepare-major": "sh ./node_modules/elastic-apm-js-core/dev-utils/prepare-release major && npm run build && npm run release",
+    "release": "npm run push-tags && npm publish && npm run github-release",
+    "push-tags": "git push origin master --follow-tags",
+    "github-release": "node ./scripts/release-github.js",
     "build": "webpack",
     "build-dev": "webpack -w",
     "build-docs": "sh ./scripts/build_docs.sh apm-agent-js-base ./docs ./build",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel-preset-react": "^6.24.1",
     "conventional-changelog-cli": "^1.3.22",
     "express": "^4.16.2",
+    "gh-release-assets": "^1.1.2",
     "http-server": "^0.10.0",
     "jasmine": "^2.8.0",
     "karma": "^3.0.0",
@@ -80,8 +81,13 @@
     "es6-promise": "^4.2.4"
   },
   "standard": {
-    "env": ["jasmine", "browser"],
-    "globals": ["browser"],
+    "env": [
+      "jasmine",
+      "browser"
+    ],
+    "globals": [
+      "browser"
+    ],
     "ignore": [
       "test/e2e/sourcemap/"
     ]

--- a/scripts/release-github.js
+++ b/scripts/release-github.js
@@ -50,7 +50,13 @@ function createRelease (token) {
 }
 
 function uploadAssets (uploadUrl, token) {
+  /**
+   * Exclude the files that are not required for releasing
+   *
+   * TODO: Remove this filtering logic once we revisit bundling steps
+   */
   const assets = fs.readdirSync(BUILD_DIR)
+    .filter(file => file.endsWith('.js'))
     .map(file => path.join(BUILD_DIR, file))
   return new Promise((resolve, reject) => {
     releaseAssets({

--- a/scripts/release-github.js
+++ b/scripts/release-github.js
@@ -22,10 +22,11 @@ function createRelease (token) {
    * To match the package version with tags
    */
   const tagVersion = 'v' + version
+  const changelogUrl = `https://github.com/elastic/apm-agent-js-base/blob/master/CHANGELOG.md`
   const postBody = {
     tag_name: tagVersion,
     name: tagVersion,
-    body: 'Please check the changelog https://github.com/elastic/apm-agent-js-base/blob/master/CHANGELOG.md',
+    body: `Please check the changelog - ${changelogUrl}`,
     draft: false,
     prerelease: false
   }
@@ -71,9 +72,10 @@ function uploadAssets (uploadUrl, token) {
     if (!token) {
       throw new Error('Please provide GITHUB_TOKEN=`token` for creating release')
     }
+    console.log('creating release for the tag - ', version)
     const response = await createRelease(token)
-    console.log('created release for the tag - ', version)
     const parsedResponse = JSON.parse(response)
+    console.log('release created', parsedResponse.url)
     const uploadUrl = parsedResponse['upload_url']
     await uploadAssets(uploadUrl, token)
     console.log('uploaded all assets to the release')

--- a/scripts/release-github.js
+++ b/scripts/release-github.js
@@ -15,7 +15,7 @@ function createRelease (token) {
     method: 'POST',
     headers: {
       'Authorization': `token ${token}`,
-      'User-Agent': 'apm js agent' + version
+      'User-Agent': 'APM RUM JS agent' + version
     }
   })
   /**

--- a/scripts/upload-assets.js
+++ b/scripts/upload-assets.js
@@ -1,0 +1,84 @@
+const path = require('path')
+const url = require('url')
+const fs = require('fs')
+const https = require('https')
+const releaseAssets = require('gh-release-assets')
+const { version } = require('../package.json')
+
+const BUILD_DIR = path.resolve(__dirname, '../dist/bundles')
+const GITHUB_URL = 'https://api.github.com/repos/elastic/apm-agent-js-base'
+
+function createRelease (token) {
+  const releaseUrl = `${GITHUB_URL}/releases`
+  const urlObj = url.parse(releaseUrl, false)
+  const options = Object.assign({}, urlObj, {
+    method: 'POST',
+    headers: {
+      'Authorization': `token ${token}`,
+      'User-Agent': 'apm js agent' + version
+    }
+  })
+  /**
+   * To match the package version with tags
+   */
+  const tagVersion = 'v' + version
+  const postBody = {
+    tag_name: tagVersion,
+    name: tagVersion,
+    body: 'Please check the changelog https://github.com/elastic/apm-agent-js-base/blob/master/CHANGELOG.md',
+    draft: false,
+    prerelease: false
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = https.request(options)
+    request.on('response', response => {
+      let chunks = ''
+      response.on('data', data => (chunks += data))
+      response.on('end', () => {
+        if (response.statusCode !== 201) {
+          reject(chunks)
+        }
+        resolve(chunks)
+      })
+    })
+    request.on('error', (err) => reject(err))
+    request.write(JSON.stringify(postBody))
+    request.end()
+  })
+}
+
+function uploadAssets (uploadUrl, token) {
+  const assets = fs.readdirSync(BUILD_DIR)
+    .map(file => path.join(BUILD_DIR, file))
+  return new Promise((resolve, reject) => {
+    releaseAssets({
+      url: uploadUrl,
+      token,
+      assets
+    }, (err, assets) => {
+      if (err) {
+        return reject(err)
+      }
+      resolve(assets)
+    })
+  })
+}
+
+(async function startRelease () {
+  try {
+    var token = process.env['GITHUB_TOKEN']
+    if (!token) {
+      throw new Error('Please provide GITHUB_TOKEN=`token` for creating release')
+    }
+    const response = await createRelease(token)
+    console.log('created release for the tag - ', version)
+    const parsedResponse = JSON.parse(response)
+    const uploadUrl = parsedResponse['upload_url']
+    await uploadAssets(uploadUrl, token)
+    console.log('uploaded all assets to the release')
+  } catch (err) {
+    console.error(err)
+    process.exit(1)
+  }
+})()


### PR DESCRIPTION
+ Created a release via this script - 
https://github.com/elastic/apm-agent-js-base/releases/tag/v2.2.0

TODO
+ [x] have to exclude license and map files from getting uploaded
+ [x] Update the docs https://github.com/elastic/apm-agent-js-base/pull/118 with release version