### PR TITLE
chore: add lock file to npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "files": [
     "src/**/*.js",
-    "dist"
+    "dist",
+    "package-lock.json"
   ],
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
+ Fix https://github.com/elastic/apm-agent-js-base/issues/114