### PR TITLE
chore: fix release script for github artificats

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "release": "lerna publish",
     "release-package": "node scripts/publish",
+    "release-github": "lerna run --scope elastic-apm-js-base test && node scripts/release-github",
     "build-docs": "sh ./scripts/build_docs.sh apm-agent-js-base ./docs ./build",
     "bootstrap": "lerna bootstrap",
     "clean": "lerna clean",

--- a/packages/rum/package.json
+++ b/packages/rum/package.json
@@ -5,7 +5,6 @@
   "main": "dist/bundles/elastic-apm-js-base.umd.js",
   "repository": "https://github.com/elastic/apm-agent-js-base/tree/master/packages/rum",
   "scripts": {
-    "github-release": "node ./scripts/release-github.js",
     "build": "webpack",
     "build-dev": "webpack -w",
     "karma": "karma start",

--- a/scripts/release-github.js
+++ b/scripts/release-github.js
@@ -28,9 +28,9 @@ const url = require('url')
 const fs = require('fs')
 const https = require('https')
 const releaseAssets = require('gh-release-assets')
-const { version } = require('../package.json')
+const { version } = require('../packages/rum/package.json')
 
-const BUILD_DIR = path.resolve(__dirname, '../dist/bundles')
+const BUILD_DIR = path.join(__dirname, '../packages/rum/dist/bundles')
 const GITHUB_URL = 'https://api.github.com/repos/elastic/apm-agent-js-base'
 
 function createRelease (token) {

--- a/scripts/release-github.js
+++ b/scripts/release-github.js
@@ -28,7 +28,7 @@ const url = require('url')
 const fs = require('fs')
 const https = require('https')
 const releaseAssets = require('gh-release-assets')
-const { version } = require('../packages/rum/package.json')
+const { name, version } = require('../packages/rum/package.json')
 
 const BUILD_DIR = path.join(__dirname, '../packages/rum/dist/bundles')
 const GITHUB_URL = 'https://api.github.com/repos/elastic/apm-agent-js-base'
@@ -46,7 +46,7 @@ function createRelease (token) {
   /**
    * To match the package version with tags
    */
-  const tagVersion = 'v' + version
+  const tagVersion = `${name}@${version}`
   const changelogUrl = `https://github.com/elastic/apm-agent-js-base/blob/master/CHANGELOG.md`
   const postBody = {
     tag_name: tagVersion,


### PR DESCRIPTION
+ part of elastic/apm-agent-js-base#146 
+ This happens after we do `lerna publish` which is covered in another PR elastic/apm-agent-js-base#164 
+ fixes elastic/apm-agent-js-base#157 
+ The tagging issue should not be a problem anymore since we rely on tag creation via lerna /cc @jahtalab 