### PR TITLE
feat(rum-core): measure all resource entries in page load

### DIFF
--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -43,6 +43,20 @@ const ADD_EVENT_LISTENER_STR = 'addEventListener'
 const REMOVE_EVENT_LISTENER_STR = 'removeEventListener'
 
 /**
+ * Resource Timing initiator types that will be captured as spans
+ */
+const RESOURCE_INITIATOR_TYPES = [
+  'link',
+  'css',
+  'script',
+  'img',
+  'xmlhttprequest',
+  'fetch',
+  'beacon',
+  'iframe'
+]
+
+/**
  * Others
  */
 const serverStringLimit = 1024
@@ -55,5 +69,6 @@ module.exports = {
   XMLHTTPREQUEST_SOURCE,
   ADD_EVENT_LISTENER_STR,
   REMOVE_EVENT_LISTENER_STR,
+  RESOURCE_INITIATOR_TYPES,
   serverStringLimit
 }

--- a/packages/rum-core/src/common/constants.js
+++ b/packages/rum-core/src/common/constants.js
@@ -57,6 +57,11 @@ const RESOURCE_INITIATOR_TYPES = [
 ]
 
 /**
+ * Maximum duration of the span that is used to decide if the span is valid - 300 secs / 5 mins
+ */
+const SPAN_THRESHOLD = 5 * 60 * 1000
+
+/**
  * Others
  */
 const serverStringLimit = 1024
@@ -70,5 +75,6 @@ module.exports = {
   ADD_EVENT_LISTENER_STR,
   REMOVE_EVENT_LISTENER_STR,
   RESOURCE_INITIATOR_TYPES,
+  SPAN_THRESHOLD,
   serverStringLimit
 }

--- a/packages/rum-core/src/performance-monitoring/capture-hard-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-hard-navigation.js
@@ -25,7 +25,10 @@
 
 const Span = require('./span')
 const Url = require('../common/url')
-const { RESOURCE_INITIATOR_TYPES } = require('../common/constants')
+const {
+  RESOURCE_INITIATOR_TYPES,
+  SPAN_THRESHOLD
+} = require('../common/constants')
 
 /**
  * Navigation Timing Spans
@@ -50,10 +53,6 @@ const eventPairs = [
   ],
   ['loadEventStart', 'loadEventEnd', 'Fire "load" event']
 ]
-/**
- * Maximum duration of the span that is used to decide if the span is valid - 30 seconds
- */
-const SPAN_THRESHOLD = 5 * 60 * 1000
 
 function isValidSpan (transaction, span) {
   const duration = span.duration()
@@ -133,10 +132,12 @@ function createResourceTimingSpans (entries, filterUrls) {
       continue
     } else if (!isValidPerformanceTiming(startTime, responseEnd)) {
       continue
-    } else if (RESOURCE_INITIATOR_TYPES.indexOf(initiatorType) !== -1) {
-      /**
-       * Create spans for all known resource initiator types
-       */
+    }
+
+    /**
+     * Create spans for all known resource initiator types
+     */
+    if (RESOURCE_INITIATOR_TYPES.indexOf(initiatorType) !== -1) {
       spans.push(
         createResourceTimingSpan(name, initiatorType, startTime, responseEnd)
       )
@@ -163,15 +164,14 @@ function createResourceTimingSpans (entries, filterUrls) {
           break
         }
       }
-      if (foundAjaxReq) {
-        continue
-      }
       /**
        * Create span if its not an ajax request
        */
-      spans.push(
-        createResourceTimingSpan(name, initiatorType, startTime, responseEnd)
-      )
+      if (!foundAjaxReq) {
+        spans.push(
+          createResourceTimingSpan(name, initiatorType, startTime, responseEnd)
+        )
+      }
     }
   }
   return spans

--- a/packages/rum-core/src/performance-monitoring/capture-hard-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-hard-navigation.js
@@ -25,72 +25,139 @@
 
 const Span = require('./span')
 const Url = require('../common/url')
+const { RESOURCE_INITIATOR_TYPES } = require('../common/constants')
 
+/**
+ * Navigation Timing Spans
+ *
+ * eventPairs[0] -> start time of span
+ * eventPairs[1] -> end time of span
+ * eventPairs[2] -> name of the span
+ */
 const eventPairs = [
   ['domainLookupStart', 'domainLookupEnd', 'Domain lookup'],
   ['connectStart', 'connectEnd', 'Making a connection to the server'],
   ['requestStart', 'responseEnd', 'Requesting and receiving the document'],
-  ['domLoading', 'domInteractive', 'Parsing the document, executing sync. scripts'],
-  ['domContentLoadedEventStart', 'domContentLoadedEventEnd', 'Fire "DOMContentLoaded" event'],
+  [
+    'domLoading',
+    'domInteractive',
+    'Parsing the document, executing sync. scripts'
+  ],
+  [
+    'domContentLoadedEventStart',
+    'domContentLoadedEventEnd',
+    'Fire "DOMContentLoaded" event'
+  ],
   ['loadEventStart', 'loadEventEnd', 'Fire "load" event']
 ]
-const spanThreshold = 5 * 60 * 1000
+/**
+ * Maximum duration of the span that is used to decide if the span is valid - 30 seconds
+ */
+const SPAN_THRESHOLD = 5 * 60 * 1000
 
 function isValidSpan (transaction, span) {
-  var d = span.duration()
+  const duration = span.duration()
   return (
-    d < spanThreshold && d > 0 && span._start <= transaction._end && span._end <= transaction._end
+    duration < SPAN_THRESHOLD &&
+    duration > 0 &&
+    span._start <= transaction._end &&
+    span._end <= transaction._end
+  )
+}
+
+function isValidPerformanceTiming (start, end, baseTime = 0) {
+  return (
+    typeof start === 'number' &&
+    typeof end === 'number' &&
+    start >= baseTime &&
+    end > start &&
+    end - start < SPAN_THRESHOLD &&
+    start - baseTime < SPAN_THRESHOLD &&
+    end - baseTime < SPAN_THRESHOLD
   )
 }
 
 function createNavigationTimingSpans (timings, baseTime) {
-  var spans = []
-  for (var i = 0; i < eventPairs.length; i++) {
-    var start = timings[eventPairs[i][0]]
-    var end = timings[eventPairs[i][1]]
-    if (
-      baseTime &&
-      start &&
-      end &&
-      end > start &&
-      start >= baseTime &&
-      end - start < spanThreshold &&
-      start - baseTime < spanThreshold &&
-      end - baseTime < spanThreshold
-    ) {
-      var span = new Span(eventPairs[i][2], 'hard-navigation.browser-timing')
-      if (eventPairs[i][0] === 'requestStart') {
-        span.pageResponse = true
-      }
-      span._start = start - baseTime
-      span.ended = true
-      span._end = end - baseTime
-      spans.push(span)
+  const spans = []
+  for (let i = 0; i < eventPairs.length; i++) {
+    const start = timings[eventPairs[i][0]]
+    const end = timings[eventPairs[i][1]]
+
+    if (!isValidPerformanceTiming(start, end, baseTime)) {
+      continue
     }
+    const span = new Span(eventPairs[i][2], 'hard-navigation.browser-timing')
+    if (eventPairs[i][0] === 'requestStart') {
+      span.pageResponse = true
+    }
+    span._start = start - baseTime
+    span.ended = true
+    span._end = end - baseTime
+    spans.push(span)
   }
   return spans
 }
 
+function createResourceTimingSpan (name, initiatorType, start, end) {
+  let kind = 'resource'
+  if (initiatorType) {
+    kind += '.' + initiatorType
+  }
+
+  const parsedUrl = new Url(name)
+  const spanName = parsedUrl.origin + parsedUrl.path
+  const span = new Span(spanName || name, kind)
+  span.addContext({
+    http: {
+      url: name
+    }
+  })
+  span._start = start
+  span.ended = true
+  span._end = end
+  return span
+}
+
 function createResourceTimingSpans (entries, filterUrls) {
-  var spans = []
-  for (var i = 0; i < entries.length; i++) {
-    var entry = entries[i]
-    var { initiatorType, name, startTime, responseEnd } = entry
+  const spans = []
+  for (let i = 0; i < entries.length; i++) {
+    let { initiatorType, name, startTime, responseEnd } = entries[i]
     /**
      * Skipping the timing information of API calls because of auto patching XHR and Fetch
      */
-    if (initiatorType === 'xmlhttprequest' || initiatorType === 'fetch' || !entry.name) {
-      continue
-    } else if (
-      initiatorType !== 'css' &&
-      initiatorType !== 'img' &&
-      initiatorType !== 'script' &&
-      initiatorType !== 'link'
+    if (
+      initiatorType === 'xmlhttprequest' ||
+      initiatorType === 'fetch' ||
+      !name
     ) {
-      // is ajax request? test for css/img before the expensive operation
-      var foundAjaxReq = false
-      for (var j = 0; j < filterUrls.length; j++) {
-        var idx = name.lastIndexOf(filterUrls[j])
+      continue
+    } else if (!isValidPerformanceTiming(startTime, responseEnd)) {
+      continue
+    } else if (RESOURCE_INITIATOR_TYPES.indexOf(initiatorType) !== -1) {
+      /**
+       * Create spans for all known resource initiator types
+       */
+      spans.push(
+        createResourceTimingSpan(name, initiatorType, startTime, responseEnd)
+      )
+    } else {
+      /**
+       * Since IE does not support initiatorType in Resource timing entry,
+       * We have to manually filter the API calls from creating duplicate Spans
+       *
+       * Skip span creation if initiatorType is other than known types specified as part of RESOURCE_INITIATOR_TYPES
+       * The reason being, there are other types like embed, video, audio, navigation etc
+       *
+       * Check the below webplatform test to know more
+       * https://github.com/web-platform-tests/wpt/blob/b0020d5df18998609b38786878f7a0b92cc680aa/resource-timing/resource_initiator_types.html#L93
+       */
+      if (initiatorType != null) {
+        continue
+      }
+
+      let foundAjaxReq = false
+      for (let j = 0; j < filterUrls.length; j++) {
+        const idx = name.lastIndexOf(filterUrls[j])
         if (idx > -1 && idx === name.length - filterUrls[j].length) {
           foundAjaxReq = true
           break
@@ -99,49 +166,28 @@ function createResourceTimingSpans (entries, filterUrls) {
       if (foundAjaxReq) {
         continue
       }
-    } else {
-      var kind = 'resource'
-      if (initiatorType) {
-        kind += '.' + initiatorType
-      }
-      var start = startTime
-      var end = responseEnd
-      if (
-        typeof start === 'number' &&
-        typeof end === 'number' &&
-        start >= 0 &&
-        end > start &&
-        end - start < spanThreshold &&
-        start < spanThreshold &&
-        end < spanThreshold
-      ) {
-        var parsedUrl = new Url(name)
-        var spanName = parsedUrl.origin + parsedUrl.path
-        var span = new Span(spanName || name, kind)
-        span.addContext({
-          http: {
-            url: name
-          }
-        })
-        span._start = start
-        span.ended = true
-        span._end = end
-        spans.push(span)
-      }
+      /**
+       * Create span if its not an ajax request
+       */
+      spans.push(
+        createResourceTimingSpan(name, initiatorType, startTime, responseEnd)
+      )
     }
   }
   return spans
 }
 
 function captureHardNavigation (transaction) {
-  if (transaction.isHardNavigation && window.performance && window.performance.timing) {
-    var timings = window.performance.timing
-    var baseTime = timings.fetchStart
+  const perf = window.performance
+  if (transaction.isHardNavigation && perf && perf.timing) {
+    const timings = perf.timing
     // must be zero otherwise the calculated relative _start time would be wrong
     transaction._start = 0
     transaction.type = 'page-load'
 
-    createNavigationTimingSpans(timings, baseTime).forEach(function (span) {
+    createNavigationTimingSpans(timings, timings.fetchStart).forEach(function (
+      span
+    ) {
       if (isValidSpan(transaction, span)) {
         span.traceId = transaction.traceId
         span.sampled = transaction.sampled
@@ -152,17 +198,18 @@ function captureHardNavigation (transaction) {
       }
     })
 
-    if (window.performance.getEntriesByType) {
-      var entries = window.performance.getEntriesByType('resource')
+    if (typeof perf.getEntriesByType === 'function') {
+      const entries = perf.getEntriesByType('resource')
 
-      var ajaxUrls = transaction.spans
-        .filter(function (span) {
-          return span.type === 'external' && span.subType === 'http'
-        })
-        .map(function (span) {
-          return span.name.split(' ')[1]
-        })
+      const ajaxUrls = []
+      for (let i = 0; i < transaction.spans; i++) {
+        const span = transaction.spans[i]
 
+        if (span.type === 'external' && span.subType === 'http') {
+          continue
+        }
+        ajaxUrls.push(span.name.split(' ')[1])
+      }
       createResourceTimingSpans(entries, ajaxUrls).forEach(function (span) {
         if (isValidSpan(transaction, span)) {
           transaction.spans.push(span)

--- a/packages/rum-core/src/performance-monitoring/transaction-service.js
+++ b/packages/rum-core/src/performance-monitoring/transaction-service.js
@@ -23,11 +23,11 @@
  *
  */
 
-var Transaction = require('./transaction')
-var utils = require('../common/utils')
-var Subscription = require('../common/subscription')
+const Transaction = require('./transaction')
+const utils = require('../common/utils')
+const Subscription = require('../common/subscription')
+const { captureHardNavigation } = require('./capture-hard-navigation')
 
-var captureHardNavigation = require('./capture-hard-navigation').captureHardNavigation
 class TransactionService {
   constructor (logger, config) {
     if (typeof config === 'undefined') {
@@ -112,7 +112,11 @@ class TransactionService {
   capturePageLoadMetrics (tr) {
     var self = this
     var capturePageLoad = self._config.get('capturePageLoad')
-    if (capturePageLoad && !self._alreadyCapturedPageLoad && tr.isHardNavigation) {
+    if (
+      capturePageLoad &&
+      !self._alreadyCapturedPageLoad &&
+      tr.isHardNavigation
+    ) {
       tr.addMarks(self.marks)
       captureHardNavigation(tr)
       self._alreadyCapturedPageLoad = true
@@ -179,7 +183,10 @@ class TransactionService {
         self._logger.debug('TransactionService transaction finished', tr)
         if (!self.shouldIgnoreTransaction(tr.name)) {
           if (type === 'page-load') {
-            if (tr.name === 'Unknown' && self._config.get('pageLoadTransactionName')) {
+            if (
+              tr.name === 'Unknown' &&
+              self._config.get('pageLoadTransactionName')
+            ) {
               tr.name = self._config.get('pageLoadTransactionName')
             }
             var captured = self.capturePageLoadMetrics(tr)

--- a/packages/rum-core/test/fixtures/navigation-timing-span-snapshot.js
+++ b/packages/rum-core/test/fixtures/navigation-timing-span-snapshot.js
@@ -25,6 +25,13 @@
 
 module.exports = [
   {
+    name: 'http://beacon.test',
+    type: 'resource.beacon',
+    ended: true,
+    _end: 168.25,
+    _start: 25.220000000000002
+  },
+  {
     name: 'http://testing.com',
     type: 'resource.script',
     ended: true,
@@ -39,7 +46,8 @@ module.exports = [
     _start: 25.385
   },
   {
-    name: 'http://localhost:9876/base/node_modules/karma-jasmine/lib/adapter.js',
+    name:
+      'http://localhost:9876/base/node_modules/karma-jasmine/lib/adapter.js',
     type: 'resource.script',
     ended: true,
     _end: 174.04500000000002,
@@ -53,7 +61,8 @@ module.exports = [
     _start: 25.640000000000004
   },
   {
-    name: 'http://localhost:9876/base/node_modules/elastic-apm-js-zone/dist/zone.js',
+    name:
+      'http://localhost:9876/base/node_modules/elastic-apm-js-zone/dist/zone.js',
     type: 'resource.script',
     ended: true,
     _end: 176.12000000000003,
@@ -102,35 +111,40 @@ module.exports = [
     _start: 26.520000000000003
   },
   {
-    name: 'http://localhost:9876/base/test/error-logging/stack-trace-service.spec.js',
+    name:
+      'http://localhost:9876/base/test/error-logging/stack-trace-service.spec.js',
     type: 'resource.script',
     ended: true,
     _end: 350.44000000000005,
     _start: 26.635
   },
   {
-    name: 'http://localhost:9876/base/test/performance-monitoring/performance-monitoring.spec.js',
+    name:
+      'http://localhost:9876/base/test/performance-monitoring/performance-monitoring.spec.js',
     type: 'resource.script',
     ended: true,
     _end: 351.72,
     _start: 26.755000000000003
   },
   {
-    name: 'http://localhost:9876/base/test/performance-monitoring/transaction-service.spec.js',
+    name:
+      'http://localhost:9876/base/test/performance-monitoring/transaction-service.spec.js',
     type: 'resource.script',
     ended: true,
     _end: 257.22,
     _start: 26.875000000000004
   },
   {
-    name: 'http://localhost:9876/base/test/performance-monitoring/transaction.spec.js',
+    name:
+      'http://localhost:9876/base/test/performance-monitoring/transaction.spec.js',
     type: 'resource.script',
     ended: true,
     _end: 187.60500000000002,
     _start: 27.035000000000004
   },
   {
-    name: 'http://localhost:9876/base/test/performance-monitoring/zone-service.spec.js',
+    name:
+      'http://localhost:9876/base/test/performance-monitoring/zone-service.spec.js',
     type: 'resource.script',
     ended: true,
     _end: 188.72000000000003,

--- a/packages/rum-core/test/fixtures/resource-entries.js
+++ b/packages/rum-core/test/fixtures/resource-entries.js
@@ -23,15 +23,8 @@
  *
  */
 
- /* eslint-disable max-len */
+/* eslint-disable max-len */
 module.exports = [
-  {
-    name: 'should not be seen',
-    initiatorType: null,
-    entryType: 'resource',
-    startTime: 25.220000000000002,
-    responseEnd: 168.25
-  },
   {
     name: null,
     initiatorType: 'script',
@@ -86,6 +79,20 @@ module.exports = [
     initiatorType: 'script',
     entryType: 'resource',
     startTime: Number(new Date()),
+    responseEnd: 168.25
+  },
+  {
+    name: 'http://ajax-filter.test',
+    initiatorType: null,
+    entryType: 'resource',
+    startTime: 25.220000000000002,
+    responseEnd: 168.25
+  },
+  {
+    name: 'http://beacon.test',
+    initiatorType: 'beacon',
+    entryType: 'resource',
+    startTime: 25.220000000000002,
     responseEnd: 168.25
   },
   {
@@ -170,7 +177,8 @@ module.exports = [
     serverTiming: []
   },
   {
-    name: 'http://localhost:9876/base/tmp/globals.js?2bb0399ca4cd37090f3846e0b277f280c8e3e9fe',
+    name:
+      'http://localhost:9876/base/tmp/globals.js?2bb0399ca4cd37090f3846e0b277f280c8e3e9fe',
     entryType: 'resource',
     startTime: 25.640000000000004,
     duration: 149.69,

--- a/packages/rum-core/test/performance-monitoring/capture-hard-navigation.spec.js
+++ b/packages/rum-core/test/performance-monitoring/capture-hard-navigation.spec.js
@@ -23,12 +23,12 @@
  *
  */
 
-var navigationTiming = require('../../src/performance-monitoring/capture-hard-navigation')
-var Transaction = require('../../src/performance-monitoring/transaction')
-
-var resourceEntries = require('../fixtures/resource-entries')
-
-var spanSnapshot = require('./navigation-timing-span-snapshot').map(mapSpan)
+const navigationTiming = require('../../src/performance-monitoring/capture-hard-navigation')
+const Transaction = require('../../src/performance-monitoring/transaction')
+const resourceEntries = require('../fixtures/resource-entries')
+const spanSnapshot = require('../fixtures/navigation-timing-span-snapshot').map(
+  mapSpan
+)
 
 function mapSpan (s) {
   return { name: s.name, _end: s._end, _start: s._start }
@@ -60,10 +60,17 @@ describe('navigationTiming', function () {
       loadEventEnd: 1528373295230
     }
 
-    var spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
+    var spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
     expect(spans.map(mapSpan)).toEqual([
       { name: 'Requesting and receiving the document', _end: 947, _start: 7 },
-      { name: 'Parsing the document, executing sync. scripts', _end: 1464, _start: 820 },
+      {
+        name: 'Parsing the document, executing sync. scripts',
+        _end: 1464,
+        _start: 820
+      },
       { name: 'Fire "DOMContentLoaded" event', _end: 1498, _start: 1464 },
       { name: 'Fire "load" event', _end: 2874, _start: 2852 }
     ])
@@ -76,80 +83,133 @@ describe('navigationTiming', function () {
     expect(spans).toEqual([])
     spans = navigationTiming.createNavigationTimingSpans(timings, 1)
     expect(spans).toEqual([])
-    spans = navigationTiming.createNavigationTimingSpans(timings, Number(new Date()))
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      Number(new Date())
+    )
     expect(spans).toEqual([])
 
     timings.requestStart = null
-    spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
     expect(spans.map(mapSpan)).toEqual([
-      { name: 'Parsing the document, executing sync. scripts', _end: 1464, _start: 820 },
+      {
+        name: 'Parsing the document, executing sync. scripts',
+        _end: 1464,
+        _start: 820
+      },
       { name: 'Fire "DOMContentLoaded" event', _end: 1498, _start: 1464 },
       { name: 'Fire "load" event', _end: 2874, _start: 2852 }
     ])
 
     timings.requestStart = undefined
-    spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
     expect(spans.map(mapSpan)).toEqual([
-      { name: 'Parsing the document, executing sync. scripts', _end: 1464, _start: 820 },
+      {
+        name: 'Parsing the document, executing sync. scripts',
+        _end: 1464,
+        _start: 820
+      },
       { name: 'Fire "DOMContentLoaded" event', _end: 1498, _start: 1464 },
       { name: 'Fire "load" event', _end: 2874, _start: 2852 }
     ])
 
     timings.requestStart = 0
-    spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
     expect(spans.map(mapSpan)).toEqual([
-      { name: 'Parsing the document, executing sync. scripts', _end: 1464, _start: 820 },
+      {
+        name: 'Parsing the document, executing sync. scripts',
+        _end: 1464,
+        _start: 820
+      },
       { name: 'Fire "DOMContentLoaded" event', _end: 1498, _start: 1464 },
       { name: 'Fire "load" event', _end: 2874, _start: 2852 }
     ])
 
     timings.requestStart = 1
-    spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
     expect(spans.map(mapSpan)).toEqual([
-      { name: 'Parsing the document, executing sync. scripts', _end: 1464, _start: 820 },
+      {
+        name: 'Parsing the document, executing sync. scripts',
+        _end: 1464,
+        _start: 820
+      },
       { name: 'Fire "DOMContentLoaded" event', _end: 1498, _start: 1464 },
       { name: 'Fire "load" event', _end: 2874, _start: 2852 }
     ])
 
     timings.requestStart = Number(new Date())
-    spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
     expect(spans.map(mapSpan)).toEqual([
-      { name: 'Parsing the document, executing sync. scripts', _end: 1464, _start: 820 },
+      {
+        name: 'Parsing the document, executing sync. scripts',
+        _end: 1464,
+        _start: 820
+      },
       { name: 'Fire "DOMContentLoaded" event', _end: 1498, _start: 1464 },
       { name: 'Fire "load" event', _end: 2874, _start: 2852 }
     ])
 
     // testing the end
     timings.domInteractive = null
-    spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
     expect(spans.map(mapSpan)).toEqual([
       { name: 'Fire "DOMContentLoaded" event', _end: 1498, _start: 1464 },
       { name: 'Fire "load" event', _end: 2874, _start: 2852 }
     ])
 
     timings.domInteractive = undefined
-    spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
     expect(spans.map(mapSpan)).toEqual([
       { name: 'Fire "DOMContentLoaded" event', _end: 1498, _start: 1464 },
       { name: 'Fire "load" event', _end: 2874, _start: 2852 }
     ])
 
     timings.domInteractive = 0
-    spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
     expect(spans.map(mapSpan)).toEqual([
       { name: 'Fire "DOMContentLoaded" event', _end: 1498, _start: 1464 },
       { name: 'Fire "load" event', _end: 2874, _start: 2852 }
     ])
 
     timings.domInteractive = 1
-    spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
     expect(spans.map(mapSpan)).toEqual([
       { name: 'Fire "DOMContentLoaded" event', _end: 1498, _start: 1464 },
       { name: 'Fire "load" event', _end: 2874, _start: 2852 }
     ])
 
     timings.domInteractive = Number(new Date())
-    spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
     expect(spans.map(mapSpan)).toEqual([
       { name: 'Fire "DOMContentLoaded" event', _end: 1498, _start: 1464 },
       { name: 'Fire "load" event', _end: 2874, _start: 2852 }
@@ -157,7 +217,10 @@ describe('navigationTiming', function () {
 
     timings.domLoading = null
     timings.domInteractive = null
-    spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
     expect(spans.map(mapSpan)).toEqual([
       { name: 'Fire "DOMContentLoaded" event', _end: 1498, _start: 1464 },
       { name: 'Fire "load" event', _end: 2874, _start: 2852 }
@@ -165,7 +228,10 @@ describe('navigationTiming', function () {
 
     timings.domLoading = undefined
     timings.domInteractive = undefined
-    spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
     expect(spans.map(mapSpan)).toEqual([
       { name: 'Fire "DOMContentLoaded" event', _end: 1498, _start: 1464 },
       { name: 'Fire "load" event', _end: 2874, _start: 2852 }
@@ -173,7 +239,10 @@ describe('navigationTiming', function () {
 
     timings.domLoading = 0
     timings.domInteractive = 0
-    spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
     expect(spans.map(mapSpan)).toEqual([
       { name: 'Fire "DOMContentLoaded" event', _end: 1498, _start: 1464 },
       { name: 'Fire "load" event', _end: 2874, _start: 2852 }
@@ -181,7 +250,10 @@ describe('navigationTiming', function () {
 
     timings.domLoading = 1
     timings.domInteractive = 1
-    spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
     expect(spans.map(mapSpan)).toEqual([
       { name: 'Fire "DOMContentLoaded" event', _end: 1498, _start: 1464 },
       { name: 'Fire "load" event', _end: 2874, _start: 2852 }
@@ -189,7 +261,10 @@ describe('navigationTiming', function () {
 
     timings.domLoading = Number(new Date())
     timings.domInteractive = Number(new Date())
-    spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
     expect(spans.map(mapSpan)).toEqual([
       { name: 'Fire "DOMContentLoaded" event', _end: 1498, _start: 1464 },
       { name: 'Fire "load" event', _end: 2874, _start: 2852 }
@@ -197,13 +272,20 @@ describe('navigationTiming', function () {
 
     timings.domContentLoadedEventStart = 'testing'
     timings.domContentLoadedEventEnd = 'testings'
-    spans = navigationTiming.createNavigationTimingSpans(timings, timings.fetchStart)
-    expect(spans.map(mapSpan)).toEqual([{ name: 'Fire "load" event', _end: 2874, _start: 2852 }])
+    spans = navigationTiming.createNavigationTimingSpans(
+      timings,
+      timings.fetchStart
+    )
+    expect(spans.map(mapSpan)).toEqual([
+      { name: 'Fire "load" event', _end: 2874, _start: 2852 }
+    ])
     // console.log(spans.map(s => `${s._start}, ${s._end}, ${s.duration()}, ${s.name}`).join('\n'))
   })
 
   it('should createResourceTimingSpans', function () {
-    var spans = navigationTiming.createResourceTimingSpans(resourceEntries, [])
+    const spans = navigationTiming.createResourceTimingSpans(resourceEntries, [
+      'http://ajax-filter.test'
+    ])
     expect(spans.map(mapSpan)).toEqual(spanSnapshot)
   })
 


### PR DESCRIPTION
+ Turned out to be a bit more extensive that I thought, There are multiple resource types that are being captured by `perf.getEntriesByType("resource")`.. List is specified here - https://github.com/web-platform-tests/wpt/blob/b0020d5df18998609b38786878f7a0b92cc680aa/resource-timing/resource_initiator_types.html#L93

+ I have added as check to create Spans for all known resource types except (embed, video, audio etc) which does not make much sense since its uncommon, We can support it in future. 

+ Refactored the code a bit to look nicer. 

+ fixes https://github.com/elastic/apm-agent-js-base/issues/161