### PR TITLE
perf(rum-core): avoid url parsing on resource timing entries

### DIFF
--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -121,10 +121,7 @@ class ApmServer {
   _createQueue(onFlush) {
     var queueLimit = this._configService.get('queueLimit')
     var flushInterval = this._configService.get('flushInterval')
-    return new Queue(onFlush, {
-      queueLimit,
-      flushInterval
-    })
+    return new Queue(onFlush, { queueLimit, flushInterval })
   }
 
   initErrorQueue() {
@@ -149,10 +146,7 @@ class ApmServer {
       function() {
         apmServer._loggingService.warn('Dropped error due to throttling!')
       },
-      {
-        limit,
-        interval
-      }
+      { limit, interval }
     )
   }
 
@@ -178,10 +172,7 @@ class ApmServer {
       function() {
         apmServer._loggingService.warn('Dropped transaction due to throttling!')
       },
-      {
-        limit,
-        interval
-      }
+      { limit, interval }
     )
   }
 
@@ -221,19 +212,18 @@ class ApmServer {
   sendErrors(errors) {
     if (this._configService.isValid() && this._configService.isActive()) {
       if (errors && errors.length > 0) {
-        var payload = {
+        const payload = {
           service: this.createServiceObject(),
           errors
         }
-
-        payload = this._configService.applyFilters(payload)
-        if (payload) {
-          var endPoint = this._configService.getEndpointUrl('errors')
-          var ndjson = this.ndjsonErrors(payload.errors)
+        const filteredPayload = this._configService.applyFilters(payload)
+        if (filteredPayload) {
+          const endPoint = this._configService.getEndpointUrl('errors')
+          const ndjson = this.ndjsonErrors(filteredPayload.errors)
           ndjson.unshift(
-            NDJSON.stringify({ metadata: { service: payload.service } })
+            NDJSON.stringify({ metadata: { service: filteredPayload.service } })
           )
-          var ndjsonPayload = ndjson.join('')
+          const ndjsonPayload = ndjson.join('')
           return this._postJson(endPoint, ndjsonPayload)
         } else {
           this._loggingService.warn('Dropped payload due to filtering!')
@@ -264,18 +254,18 @@ class ApmServer {
   sendTransactions(transactions) {
     if (this._configService.isValid() && this._configService.isActive()) {
       if (transactions && transactions.length > 0) {
-        var payload = {
+        const payload = {
           service: this.createServiceObject(),
           transactions
         }
-        payload = this._configService.applyFilters(payload)
-        if (payload) {
-          var endPoint = this._configService.getEndpointUrl('transactions')
-          var ndjson = this.ndjsonTransactions(payload.transactions)
+        const filteredPayload = this._configService.applyFilters(payload)
+        if (filteredPayload) {
+          const endPoint = this._configService.getEndpointUrl('transactions')
+          const ndjson = this.ndjsonTransactions(filteredPayload.transactions)
           ndjson.unshift(
-            NDJSON.stringify({ metadata: { service: payload.service } })
+            NDJSON.stringify({ metadata: { service: filteredPayload.service } })
           )
-          var ndjsonPayload = ndjson.join('')
+          const ndjsonPayload = ndjson.join('')
           return this._postJson(endPoint, ndjsonPayload)
         } else {
           this._loggingService.warn('Dropped payload due to filtering!')

--- a/packages/rum-core/src/performance-monitoring/capture-hard-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-hard-navigation.js
@@ -24,11 +24,11 @@
  */
 
 const Span = require('./span')
-const Url = require('../common/url')
 const {
   RESOURCE_INITIATOR_TYPES,
   SPAN_THRESHOLD
 } = require('../common/constants')
+const { stripQueryStringFromUrl } = require('../common/utils')
 
 /**
  * Navigation Timing Spans
@@ -102,15 +102,17 @@ function createResourceTimingSpan(name, initiatorType, start, end) {
   if (initiatorType) {
     kind += '.' + initiatorType
   }
+  const spanName = stripQueryStringFromUrl(name)
+  const span = new Span(spanName, kind)
+  /**
+   * Add context information when the span name and entry name are different
+   */
+  if (spanName !== name) {
+    span.addContext({
+      http: { url: name }
+    })
+  }
 
-  const parsedUrl = new Url(name)
-  const spanName = parsedUrl.origin + parsedUrl.path
-  const span = new Span(spanName || name, kind)
-  span.addContext({
-    http: {
-      url: name
-    }
-  })
   span._start = start
   span.ended = true
   span._end = end

--- a/packages/rum-core/src/performance-monitoring/capture-hard-navigation.js
+++ b/packages/rum-core/src/performance-monitoring/capture-hard-navigation.js
@@ -104,15 +104,7 @@ function createResourceTimingSpan(name, initiatorType, start, end) {
   }
   const spanName = stripQueryStringFromUrl(name)
   const span = new Span(spanName, kind)
-  /**
-   * Add context information when the span name and entry name are different
-   */
-  if (spanName !== name) {
-    span.addContext({
-      http: { url: name }
-    })
-  }
-
+  span.addContext({ http: { url: name } })
   span._start = start
   span.ended = true
   span._end = end

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -238,12 +238,12 @@ class PerformanceMonitoring {
   }
 
   createTransactionDataModel(transaction) {
-    var configContext = this._configService.get('context')
-    var stringLimit = this._configService.get('serverStringLimit')
-    var transactionStart = transaction._start
+    const configContext = this._configService.get('context')
+    const stringLimit = this._configService.get('serverStringLimit')
+    const transactionStart = transaction._start
 
-    var spans = transaction.spans.map(function(span) {
-      var context
+    const spans = transaction.spans.map(function(span) {
+      let context
       if (span.context) {
         context = sanitizeObjectStrings(span.context, stringLimit)
       }
@@ -282,30 +282,27 @@ class PerformanceMonitoring {
 
   createTransactionPayload(transaction) {
     this.prepareTransaction(transaction)
-    var filtered = this.filterTransaction(transaction)
+    const filtered = this.filterTransaction(transaction)
     if (filtered) {
       return this.createTransactionDataModel(transaction)
     }
   }
 
   sendTransactions(transactions) {
-    var payload = transactions
-      .map(this.createTransactionPayload.bind(this))
-      .filter(function(tr) {
-        return tr
-      })
+    const payload = transactions.map(tr => this.createTransactionPayload(tr))
+
     this._logginService.debug(
       'Sending Transactions to apm server.',
       transactions.length
     )
 
     // todo: check if transactions are already being sent
-    var promise = this._apmServer.sendTransactions(payload)
+    const promise = this._apmServer.sendTransactions(payload)
     return promise
   }
 
   convertTransactionsToServerModel(transactions) {
-    return transactions.map(this.createTransactionDataModel.bind(this))
+    return transactions.map(tr => this.createTransactionDataModel(tr))
   }
 
   groupSmallContinuouslySimilarSpans(transaction, threshold) {

--- a/packages/rum-core/src/performance-monitoring/performance-monitoring.js
+++ b/packages/rum-core/src/performance-monitoring/performance-monitoring.js
@@ -289,7 +289,9 @@ class PerformanceMonitoring {
   }
 
   sendTransactions(transactions) {
-    const payload = transactions.map(tr => this.createTransactionPayload(tr))
+    const payload = transactions
+      .map(tr => this.createTransactionPayload(tr))
+      .filter(tr => tr)
 
     this._logginService.debug(
       'Sending Transactions to apm server.',

--- a/packages/rum-core/src/performance-monitoring/transaction.js
+++ b/packages/rum-core/src/performance-monitoring/transaction.js
@@ -54,10 +54,10 @@ class Transaction extends SpanBase {
   }
 
   addNavigationTimingMarks() {
-    var marks = getNavigationTimingMarks()
-    var paintMarks = getPaintTimingMarks()
+    const marks = getNavigationTimingMarks()
+    const paintMarks = getPaintTimingMarks()
     if (marks) {
-      var agent = {
+      const agent = {
         timeToFirstByte: marks.responseStart,
         domInteractive: marks.domInteractive,
         domComplete: marks.domComplete
@@ -74,9 +74,9 @@ class Transaction extends SpanBase {
   }
 
   mark(key) {
-    var skey = removeInvalidChars(key)
-    var now = window.performance.now() - this._start
-    var custom = {}
+    const skey = removeInvalidChars(key)
+    const now = window.performance.now() - this._start
+    const custom = {}
     custom[skey] = now
     this.addMarks({ custom })
   }
@@ -91,11 +91,10 @@ class Transaction extends SpanBase {
     if (this.ended) {
       return
     }
-    var transaction = this
-    var opts = extend({}, options)
+    const opts = extend({}, options)
 
-    opts.onEnd = function(trc) {
-      transaction._onSpanEnd(trc)
+    opts.onEnd = trc => {
+      this._onSpanEnd(trc)
     }
     opts.traceId = this.traceId
     opts.sampled = this.sampled
@@ -104,15 +103,14 @@ class Transaction extends SpanBase {
       opts.parentId = this.id
     }
 
-    var span = new Span(name, type, opts)
+    const span = new Span(name, type, opts)
     this._activeSpans[span.id] = span
 
     return span
   }
 
   isFinished() {
-    var scheduledTasks = Object.keys(this._scheduledTasks)
-    return scheduledTasks.length === 0
+    return Object.keys(this._scheduledTasks).length === 0
   }
 
   detectFinish() {
@@ -126,13 +124,13 @@ class Transaction extends SpanBase {
     this.ended = true
     this._end = window.performance.now()
     // truncate active spans
-    for (var sid in this._activeSpans) {
-      var span = this._activeSpans[sid]
+    for (let sid in this._activeSpans) {
+      const span = this._activeSpans[sid]
       span.type = span.type + '.truncated'
       span.end()
     }
 
-    var metadata = getPageMetadata()
+    const metadata = getPageMetadata()
     this.addContext(metadata)
 
     this._adjustStartToEarliestSpan()
@@ -169,15 +167,15 @@ class Transaction extends SpanBase {
   }
 
   _adjustEndToLatestSpan() {
-    var latestSpan = findLatestNonXHRSpan(this.spans)
+    const latestSpan = findLatestNonXHRSpan(this.spans)
 
     if (latestSpan) {
       this._end = latestSpan._end
 
       // set all spans that now are longer than the transaction to
       // be truncated spans
-      for (var i = 0; i < this.spans.length; i++) {
-        var span = this.spans[i]
+      for (let i = 0; i < this.spans.length; i++) {
+        const span = this.spans[i]
         if (span._end > this._end) {
           span._end = this._end
           span.type = span.type + '.truncated'
@@ -190,7 +188,7 @@ class Transaction extends SpanBase {
   }
 
   _adjustStartToEarliestSpan() {
-    var span = getEarliestSpan(this.spans)
+    const span = getEarliestSpan(this.spans)
 
     if (span && span._start < this._start) {
       this._start = span._start
@@ -199,9 +197,9 @@ class Transaction extends SpanBase {
 }
 
 function findLatestNonXHRSpan(spans) {
-  var latestSpan = null
-  for (var i = 0; i < spans.length; i++) {
-    var span = spans[i]
+  let latestSpan = null
+  for (let i = 0; i < spans.length; i++) {
+    const span = spans[i]
     if (
       span.type &&
       span.type.indexOf('ext') === -1 &&
@@ -215,7 +213,7 @@ function findLatestNonXHRSpan(spans) {
 }
 
 function getEarliestSpan(spans) {
-  var earliestSpan = null
+  let earliestSpan = null
 
   spans.forEach(function(span) {
     if (!earliestSpan) {


### PR DESCRIPTION
+ Resource timing entries name have fully resolved URL as part of the SPEC and we dont really need to  parse them again based on the window base URL. 

+ The context information is sent only when the Entry Name is different from Span name -> Happens when the resource contains query strings in URL. small optimisation for reducing the payload to APM server. 