### PR TITLE
chore: modify notice generation script [skip ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ html_docs
 build
 reports
 coverage
+
+# ignore lerna-debug and npm-debug logs
+*debug.log

--- a/dev-utils/dep-info.js
+++ b/dev-utils/dep-info.js
@@ -26,7 +26,7 @@
 const { join } = require('path')
 const { readFileSync, writeFileSync, readdirSync } = require('fs')
 
-function getFileContent (directory, filename) {
+function getFileContent(directory, filename) {
   var files = readdirSync(directory)
   var licenseFile = files.find(f => f.toLowerCase().startsWith(filename.toLowerCase()))
   if (licenseFile) {
@@ -35,7 +35,7 @@ function getFileContent (directory, filename) {
   }
 }
 
-function generateDependencyInfo (deps, modulesPath) {
+function generateDependencyInfo(deps, modulesPath) {
   var allLicenses = []
   deps.forEach(d => {
     var modulePath = join(modulesPath, d)
@@ -56,7 +56,7 @@ function generateDependencyInfo (deps, modulesPath) {
   return allLicenses
 }
 
-function generateNotice () {
+function generateNotice() {
   const packagesDir = join(__dirname, '../packages')
   const packageList = readdirSync(packagesDir).reverse()
 
@@ -70,19 +70,19 @@ function generateNotice () {
       join(packageDir, 'node_modules')
     )
     let allLicenses = `
-  ${name}
-  Copyright (c) 2017-present, Elasticsearch BV
+${name}
+Copyright (c) 2017-present, Elasticsearch BV
 
-  `
+`
     depInfo.forEach(d => {
       if (d.license || d.notice) {
         allLicenses += `
-  ---
-  This product relies on ${d.name}
+---
+This product relies on ${d.name}
 
-  ${d.license ? d.license : ''}
+${d.license ? d.license : ''}
 
-  ${d.notice ? d.notice : ''}`
+${d.notice ? d.notice : ''}`
       }
     })
     writeFileSync(join(packageDir, './NOTICE.txt'), allLicenses)

--- a/dev-utils/dep-info.js
+++ b/dev-utils/dep-info.js
@@ -23,14 +23,14 @@
  *
  */
 
-const path = require('path')
+const { join } = require('path')
 const { readFileSync, writeFileSync, readdirSync } = require('fs')
 
 function getFileContent (directory, filename) {
   var files = readdirSync(directory)
   var licenseFile = files.find(f => f.toLowerCase().startsWith(filename.toLowerCase()))
   if (licenseFile) {
-    var license = readFileSync(path.join(directory, licenseFile), 'utf8')
+    var license = readFileSync(join(directory, licenseFile), 'utf8')
     return license
   }
 }
@@ -38,7 +38,7 @@ function getFileContent (directory, filename) {
 function generateDependencyInfo (deps, modulesPath) {
   var allLicenses = []
   deps.forEach(d => {
-    var modulePath = path.join(modulesPath, d)
+    var modulePath = join(modulesPath, d)
     var license = getFileContent(modulePath, 'LICENSE')
     var dep = {
       name: d
@@ -56,32 +56,37 @@ function generateDependencyInfo (deps, modulesPath) {
   return allLicenses
 }
 
-function generateNotice (rootDir) {
-  if (!rootDir) rootDir = './'
-  const { dependencies, name } = JSON.parse(
-    readFileSync(path.join(rootDir, './package.json'), 'utf8')
-  )
-  var depInfo = generateDependencyInfo(
-    Object.keys(dependencies),
-    path.join(rootDir, './node_modules')
-  )
-  var allLicenses = `
-${name}
-Copyright (c) 2017-present, Elasticsearch BV
+function generateNotice () {
+  const packagesDir = join(__dirname, '../packages')
+  const packageList = readdirSync(packagesDir).reverse()
 
-`
-  depInfo.forEach(d => {
-    if (d.license || d.notice) {
-      allLicenses += `
----
-This product relies on ${d.name}
+  for (const packageName of packageList) {
+    const packageDir = join(packagesDir, packageName)
+    const { dependencies, name } = JSON.parse(
+      readFileSync(join(packageDir, 'package.json'), 'utf8')
+    )
+    const depInfo = generateDependencyInfo(
+      Object.keys(dependencies),
+      join(packageDir, 'node_modules')
+    )
+    let allLicenses = `
+  ${name}
+  Copyright (c) 2017-present, Elasticsearch BV
 
-${d.license ? d.license : ''}
+  `
+    depInfo.forEach(d => {
+      if (d.license || d.notice) {
+        allLicenses += `
+  ---
+  This product relies on ${d.name}
 
-${d.notice ? d.notice : ''}`
-    }
-  })
-  writeFileSync(path.join(rootDir, './NOTICE.txt'), allLicenses)
+  ${d.license ? d.license : ''}
+
+  ${d.notice ? d.notice : ''}`
+      }
+    })
+    writeFileSync(join(packageDir, './NOTICE.txt'), allLicenses)
+  }
 }
 
 module.exports = {

--- a/packages/rum-core/NOTICE.txt
+++ b/packages/rum-core/NOTICE.txt
@@ -1,12 +1,12 @@
 
-  elastic-apm-js-core
-  Copyright (c) 2017-present, Elasticsearch BV
+elastic-apm-js-core
+Copyright (c) 2017-present, Elasticsearch BV
 
-  
-  ---
-  This product relies on error-stack-parser
 
-  This is free and unencumbered software released into the public domain.
+---
+This product relies on error-stack-parser
+
+This is free and unencumbered software released into the public domain.
 
 Anyone is free to copy, modify, publish, use, compile, sell, or
 distribute this software, either in source code form or as a compiled
@@ -32,11 +32,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org>
 
 
-  
-  ---
-  This product relies on opentracing
 
-  Copyright (c) 2016 Resonance Labs, Inc
+---
+This product relies on opentracing
+
+Copyright (c) 2016 Resonance Labs, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -57,11 +57,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-  
-  ---
-  This product relies on stack-generator
 
-  This is free and unencumbered software released into the public domain.
+---
+This product relies on stack-generator
+
+This is free and unencumbered software released into the public domain.
 
 Anyone is free to copy, modify, publish, use, compile, sell, or
 distribute this software, either in source code form or as a compiled
@@ -87,11 +87,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org>
 
 
-  
-  ---
-  This product relies on uuid
 
-  The MIT License (MIT)
+---
+This product relies on uuid
+
+The MIT License (MIT)
 
 Copyright (c) 2010-2016 Robert Kieffer and other contributors
 
@@ -114,4 +114,3 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-  

--- a/packages/rum-core/NOTICE.txt
+++ b/packages/rum-core/NOTICE.txt
@@ -1,43 +1,12 @@
 
-elastic-apm-js-base
-Copyright (c) 2017-present, Elasticsearch BV
+  elastic-apm-js-core
+  Copyright (c) 2017-present, Elasticsearch BV
 
+  
+  ---
+  This product relies on error-stack-parser
 
----
-This product relies on elastic-apm-js-core
-
-MIT License
-
-Copyright (c) 2017-present, Elasticsearch BV
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-
-
-elastic-apm-js-core
-Copyright (c) 2017-present, Elasticsearch BV
-
-
----
-This product relies on error-stack-parser
-
-This is free and unencumbered software released into the public domain.
+  This is free and unencumbered software released into the public domain.
 
 Anyone is free to copy, modify, publish, use, compile, sell, or
 distribute this software, either in source code form or as a compiled
@@ -63,11 +32,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org>
 
 
+  
+  ---
+  This product relies on opentracing
 
----
-This product relies on opentracing
-
-Copyright (c) 2016 Resonance Labs, Inc
+  Copyright (c) 2016 Resonance Labs, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -88,11 +57,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
+  
+  ---
+  This product relies on stack-generator
 
----
-This product relies on stack-generator
-
-This is free and unencumbered software released into the public domain.
+  This is free and unencumbered software released into the public domain.
 
 Anyone is free to copy, modify, publish, use, compile, sell, or
 distribute this software, either in source code form or as a compiled
@@ -118,39 +87,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org>
 
 
+  
+  ---
+  This product relies on uuid
 
----
-This product relies on url-parse
-
-The MIT License (MIT)
-
-Copyright (c) 2015 Unshift.io, Arnout Kazemier,  the Contributors.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-
-
----
-This product relies on uuid
-
-The MIT License (MIT)
+  The MIT License (MIT)
 
 Copyright (c) 2010-2016 Robert Kieffer and other contributors
 
@@ -173,28 +114,4 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-
----
-This product relies on es6-promise
-
-Copyright (c) 2014 Yehuda Katz, Tom Dale, Stefan Penner and contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
+  

--- a/packages/rum-core/README.md
+++ b/packages/rum-core/README.md
@@ -1,0 +1,1 @@
+TODO: Provide description.

--- a/packages/rum/NOTICE.txt
+++ b/packages/rum/NOTICE.txt
@@ -1,22 +1,22 @@
 
-  elastic-apm-js-base
-  Copyright (c) 2017-present, Elasticsearch BV
+elastic-apm-js-base
+Copyright (c) 2017-present, Elasticsearch BV
 
-  
-  ---
-  This product relies on elastic-apm-js-core
 
-  
+---
+This product relies on elastic-apm-js-core
 
-  
-  elastic-apm-js-core
-  Copyright (c) 2017-present, Elasticsearch BV
 
-  
-  ---
-  This product relies on error-stack-parser
 
-  This is free and unencumbered software released into the public domain.
+
+elastic-apm-js-core
+Copyright (c) 2017-present, Elasticsearch BV
+
+
+---
+This product relies on error-stack-parser
+
+This is free and unencumbered software released into the public domain.
 
 Anyone is free to copy, modify, publish, use, compile, sell, or
 distribute this software, either in source code form or as a compiled
@@ -42,11 +42,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org>
 
 
-  
-  ---
-  This product relies on opentracing
 
-  Copyright (c) 2016 Resonance Labs, Inc
+---
+This product relies on opentracing
+
+Copyright (c) 2016 Resonance Labs, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -67,11 +67,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-  
-  ---
-  This product relies on stack-generator
 
-  This is free and unencumbered software released into the public domain.
+---
+This product relies on stack-generator
+
+This is free and unencumbered software released into the public domain.
 
 Anyone is free to copy, modify, publish, use, compile, sell, or
 distribute this software, either in source code form or as a compiled
@@ -97,11 +97,11 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org>
 
 
-  
-  ---
-  This product relies on uuid
 
-  The MIT License (MIT)
+---
+This product relies on uuid
+
+The MIT License (MIT)
 
 Copyright (c) 2010-2016 Robert Kieffer and other contributors
 
@@ -124,11 +124,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-  
-  ---
-  This product relies on es6-promise
 
-  Copyright (c) 2014 Yehuda Katz, Tom Dale, Stefan Penner and contributors
+---
+This product relies on es6-promise
+
+Copyright (c) 2014 Yehuda Katz, Tom Dale, Stefan Penner and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -149,4 +149,3 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
-  

--- a/packages/rum/NOTICE.txt
+++ b/packages/rum/NOTICE.txt
@@ -1,0 +1,152 @@
+
+  elastic-apm-js-base
+  Copyright (c) 2017-present, Elasticsearch BV
+
+  
+  ---
+  This product relies on elastic-apm-js-core
+
+  
+
+  
+  elastic-apm-js-core
+  Copyright (c) 2017-present, Elasticsearch BV
+
+  
+  ---
+  This product relies on error-stack-parser
+
+  This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>
+
+
+  
+  ---
+  This product relies on opentracing
+
+  Copyright (c) 2016 Resonance Labs, Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+  
+  ---
+  This product relies on stack-generator
+
+  This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>
+
+
+  
+  ---
+  This product relies on uuid
+
+  The MIT License (MIT)
+
+Copyright (c) 2010-2016 Robert Kieffer and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+  
+  ---
+  This product relies on es6-promise
+
+  Copyright (c) 2014 Yehuda Katz, Tom Dale, Stefan Penner and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+  

--- a/packages/rum/NOTICE.txt
+++ b/packages/rum/NOTICE.txt
@@ -6,6 +6,27 @@ Copyright (c) 2017-present, Elasticsearch BV
 ---
 This product relies on elastic-apm-js-core
 
+MIT License
+
+Copyright (c) 2017-present, Elasticsearch BV
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 


### PR DESCRIPTION
+ Generate notices for all packages. 
+ Notice and Readme is automatically published with NPM, so no need of including in files array in package.json