### PR TITLE
feat(rum-core): add service env to metadata payload

### DIFF
--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -57,6 +57,16 @@ var options = {
 ----
 
 [float]
+[[environment]]
+=== `environment`
+
+* *Type:* String
+* *Default:* ``
+
+Environment where the service being monitored is deployed, e.g. production/development/test
+
+
+[float]
 [[log-level]]
 === `logLevel`
 

--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -71,11 +71,7 @@ class ApmServer {
       language: {
         name: 'javascript'
       },
-      environment: sanitizeString(cfg.get('environment'), stringLimit),
-      runtime: {
-        name: 'browser',
-        version: ''
-      }
+      environment: sanitizeString(cfg.get('environment'), stringLimit)
     }
     return serviceObject
   }

--- a/packages/rum-core/src/common/apm-server.js
+++ b/packages/rum-core/src/common/apm-server.js
@@ -58,18 +58,23 @@ class ApmServer {
   }
 
   createServiceObject() {
-    var cfg = this._configService
-    var stringLimit = cfg.get('serverStringLimit')
+    const cfg = this._configService
+    const stringLimit = cfg.get('serverStringLimit')
 
-    var serviceObject = {
+    const serviceObject = {
       name: sanitizeString(cfg.get('serviceName'), stringLimit, true),
-      version: sanitizeString(cfg.get('serviceVersion'), stringLimit, false),
+      version: sanitizeString(cfg.get('serviceVersion'), stringLimit),
       agent: {
-        name: cfg.get('agentName'),
-        version: cfg.get('agentVersion')
+        name: sanitizeString(cfg.get('agentName'), stringLimit),
+        version: sanitizeString(cfg.get('agentVersion'), stringLimit)
       },
       language: {
         name: 'javascript'
+      },
+      environment: sanitizeString(cfg.get('environment'), stringLimit),
+      runtime: {
+        name: 'browser',
+        version: ''
       }
     }
     return serviceObject

--- a/packages/rum-core/src/common/config-service.js
+++ b/packages/rum-core/src/common/config-service.js
@@ -68,6 +68,7 @@ class Config {
     this.defaults = {
       serviceName: '',
       serviceVersion: '',
+      environment: '',
       agentName: 'js-base',
       agentVersion: '%%agent-version%%',
       serverUrl: 'http://localhost:8200',

--- a/packages/rum-core/src/common/utils.js
+++ b/packages/rum-core/src/common/utils.js
@@ -23,10 +23,11 @@
  *
  */
 
-const constants = require('./constants')
-const slice = [].slice
+const { serverStringLimit } = require('./constants')
 const Url = require('../common/url')
 const rng = require('uuid/lib/rng-browser')
+
+const slice = [].slice
 
 function isCORSSupported() {
   var xhr = new window.XMLHttpRequest()
@@ -134,12 +135,17 @@ function isPlatformSupported() {
   )
 }
 
-function sanitizeString(value, limit, required, placeholder) {
+function sanitizeString(
+  value,
+  limit = serverStringLimit,
+  required = false,
+  placeholder = 'NA'
+) {
   if (typeof value === 'number') {
     value = String(value)
   }
   if (required && !value) {
-    value = placeholder || 'NA'
+    value = placeholder
   }
   if (value) {
     return String(value).substr(0, limit)
@@ -151,7 +157,7 @@ function sanitizeString(value, limit, required, placeholder) {
 function setTag(key, value, obj) {
   if (!obj || !key) return
   var skey = removeInvalidChars(key)
-  obj[skey] = sanitizeString(value, constants.serverStringLimit)
+  obj[skey] = sanitizeString(value, serverStringLimit)
   return obj
 }
 

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -23,10 +23,9 @@
  *
  */
 
-var ApmServer = require('../../src/common/apm-server')
-var Transaction = require('../../src/performance-monitoring/transaction')
-// var performanceMonitoring = require('../../src/performance-monitoring/performance-monitoring')
-var createServiceFactory = require('..').createServiceFactory
+const ApmServer = require('../../src/common/apm-server')
+const Transaction = require('../../src/performance-monitoring/transaction')
+const { createServiceFactory } = require('../')
 
 function generateTransaction(count) {
   var result = []
@@ -363,6 +362,25 @@ describe('ApmServer', function() {
     result = apmServer.sendTransactions([{ test: 'test' }])
     expect(result).toBeUndefined()
     expect(apmServer._postJson).not.toHaveBeenCalled()
+  })
+
+  it('should set service object from config along with defaults', () => {
+    configService.setConfig({
+      serviceName: 'test',
+      serviceVersion: '0.0.1',
+      environment: 'staging',
+      agentName: 'rum',
+      agentVersion: '3.0.0'
+    })
+
+    expect(apmServer.createServiceObject()).toEqual({
+      name: 'test',
+      version: '0.0.1',
+      environment: 'staging',
+      agent: { name: 'rum', version: '3.0.0' },
+      language: { name: 'javascript' },
+      runtime: { name: 'browser', version: '' }
+    })
   })
 
   it('should ndjson transactions', function() {

--- a/packages/rum-core/test/common/apm-server.spec.js
+++ b/packages/rum-core/test/common/apm-server.spec.js
@@ -378,8 +378,7 @@ describe('ApmServer', function() {
       version: '0.0.1',
       environment: 'staging',
       agent: { name: 'rum', version: '3.0.0' },
-      language: { name: 'javascript' },
-      runtime: { name: 'browser', version: '' }
+      language: { name: 'javascript' }
     })
   })
 


### PR DESCRIPTION
+ fixes elastic/apm-agent-js-base#48 
+ Users can add an option to override the environment where the service being monitored is deployed. Add the doc for the same. 